### PR TITLE
Add simple Playwright scenario runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,36 @@
 # easy-website-test
 
-test
+This repository provides a minimal example of running scripted browser actions.
+Steps are described in a JSON scenario file and executed with [Playwright](https://playwright.dev/).
+
+## Usage
+
+1. Install dependencies (requires network access):
+   ```bash
+   pip install -r requirements.txt
+   playwright install
+   ```
+2. Create a scenario JSON file or use `example_scenario.json`.
+3. Run the scenario:
+   ```bash
+   python runner.py example_scenario.json
+   ```
+
+## Scenario format
+
+A scenario is a list of steps:
+```json
+[
+  {"action": "goto", "url": "https://example.com"},
+  {"action": "click", "selector": "text=More information"},
+  {"action": "fill", "selector": "#search", "text": "hello"}
+]
+```
+Supported actions: `goto`, `click`, `fill`.
+
+## Testing
+
+Unit tests cover loading of scenario files:
+```bash
+pytest
+```

--- a/example_scenario.json
+++ b/example_scenario.json
@@ -1,0 +1,4 @@
+[
+  {"action": "goto", "url": "https://example.com"},
+  {"action": "click", "selector": "text=More information"}
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+playwright

--- a/runner.py
+++ b/runner.py
@@ -1,0 +1,41 @@
+import json
+from typing import List, Dict
+
+
+def load_steps(path: str) -> List[Dict[str, str]]:
+    """Load a scenario JSON file and return list of steps."""
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    if not isinstance(data, list):
+        raise ValueError("Scenario file must contain a list of steps")
+    return data
+
+
+def run_steps(steps: List[Dict[str, str]]) -> None:
+    """Execute the given steps using Playwright."""
+    from playwright.sync_api import sync_playwright
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch()
+        page = browser.new_page()
+        for step in steps:
+            action = step.get("action")
+            if action == "goto":
+                page.goto(step["url"])
+            elif action == "click":
+                page.click(step["selector"])
+            elif action == "fill":
+                page.fill(step["selector"], step["text"])
+            else:
+                raise ValueError(f"Unknown action: {action}")
+        browser.close()
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run a simple web scenario")
+    parser.add_argument("scenario", help="Path to scenario JSON file")
+    args = parser.parse_args()
+    steps = load_steps(args.scenario)
+    run_steps(steps)

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,0 +1,11 @@
+import sys
+import pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from runner import load_steps
+
+def test_load_steps(tmp_path):
+    scenario = tmp_path / "scenario.json"
+    scenario.write_text('[{"action": "goto", "url": "https://example.com"}]')
+    steps = load_steps(str(scenario))
+    assert steps == [{"action": "goto", "url": "https://example.com"}]


### PR DESCRIPTION
## Summary
- implement `runner.py` for executing JSON-defined browser steps via Playwright
- document usage and scenario format in README
- provide example scenario and loader unit test

## Testing
- `python -m py_compile runner.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a56e4802bc8320b5c867daac60b6a2