### PR TITLE
Validate scenario step structure

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -8,6 +8,11 @@ def load_steps(path: str) -> List[Dict[str, str]]:
         data = json.load(f)
     if not isinstance(data, list):
         raise ValueError("Scenario file must contain a list of steps")
+    for step in data:
+        if not isinstance(step, dict):
+            raise ValueError("Each step must be a dictionary")
+        if "action" not in step:
+            raise ValueError("Each step must include an 'action'")
     return data
 
 

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,11 +1,28 @@
 import sys
 import pathlib
+import pytest
+
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
 from runner import load_steps
+
 
 def test_load_steps(tmp_path):
     scenario = tmp_path / "scenario.json"
     scenario.write_text('[{"action": "goto", "url": "https://example.com"}]')
     steps = load_steps(str(scenario))
     assert steps == [{"action": "goto", "url": "https://example.com"}]
+
+
+def test_load_steps_requires_action(tmp_path):
+    scenario = tmp_path / "scenario.json"
+    scenario.write_text('[{"url": "https://example.com"}]')
+    with pytest.raises(ValueError):
+        load_steps(str(scenario))
+
+
+def test_load_steps_requires_dict(tmp_path):
+    scenario = tmp_path / "scenario.json"
+    scenario.write_text('[123]')
+    with pytest.raises(ValueError):
+        load_steps(str(scenario))


### PR DESCRIPTION
## Summary
- ensure scenario steps are dictionaries with an `action`
- cover invalid scenarios with new tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a5776620488320af0891f017205214