### PR TITLE
Validate actions in scenario loader

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -1,6 +1,10 @@
 import json
 from typing import List, Dict
 
+# Supported step actions. Keeping this in a single place makes it easy to
+# validate scenarios before trying to execute them.
+ALLOWED_ACTIONS = {"goto", "click", "fill"}
+
 
 def load_steps(path: str) -> List[Dict[str, str]]:
     """Load a scenario JSON file and return list of steps."""
@@ -11,8 +15,11 @@ def load_steps(path: str) -> List[Dict[str, str]]:
     for step in data:
         if not isinstance(step, dict):
             raise ValueError("Each step must be a dictionary")
-        if "action" not in step:
+        action = step.get("action")
+        if action is None:
             raise ValueError("Each step must include an 'action'")
+        if action not in ALLOWED_ACTIONS:
+            raise ValueError(f"Unknown action: {action}")
     return data
 
 

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -26,3 +26,10 @@ def test_load_steps_requires_dict(tmp_path):
     scenario.write_text('[123]')
     with pytest.raises(ValueError):
         load_steps(str(scenario))
+
+
+def test_load_steps_unknown_action(tmp_path):
+    scenario = tmp_path / "scenario.json"
+    scenario.write_text('[{"action": "dance"}]')
+    with pytest.raises(ValueError):
+        load_steps(str(scenario))


### PR DESCRIPTION
## Summary
- validate that each step uses a supported action before running
- add tests for scenarios with unknown actions

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a57bc610f88320b86b5a539817381b