### PR TITLE
Support waiting for selectors and URL assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,27 @@ A scenario is a list of steps:
 [
   {"action": "goto", "url": "https://example.com"},
   {"action": "click", "selector": "text=More information"},
-  {"action": "fill", "selector": "#search", "text": "hello"}
+  {"action": "fill", "selector": "#search", "text": "hello"},
+  {"action": "wait_for_selector", "selector": "#result"},
+  {"action": "assert_url_contains", "text": "example"}
 ]
 ```
-Supported actions: `goto`, `click`, `fill`.
+Supported actions: `goto`, `click`, `fill`, `wait_for_selector`, `assert_url_contains`.
+
+### Example: open a YouTube video
+
+`youtube_scenario.json` demonstrates navigating to the YouTube homepage, clicking the first
+video link, and asserting that the browser lands on a watch page:
+
+```json
+[
+  {"action": "goto", "url": "https://www.youtube.com"},
+  {"action": "wait_for_selector", "selector": "ytd-rich-grid-media a#video-title"},
+  {"action": "click", "selector": "ytd-rich-grid-media a#video-title"},
+  {"action": "wait_for_selector", "selector": "ytd-watch-flexy"},
+  {"action": "assert_url_contains", "text": "watch"}
+]
+```
 
 ## Testing
 

--- a/runner.py
+++ b/runner.py
@@ -3,7 +3,13 @@ from typing import List, Dict
 
 # Supported step actions. Keeping this in a single place makes it easy to
 # validate scenarios before trying to execute them.
-ALLOWED_ACTIONS = {"goto", "click", "fill"}
+ALLOWED_ACTIONS = {
+    "goto",
+    "click",
+    "fill",
+    "wait_for_selector",
+    "assert_url_contains",
+}
 
 
 def load_steps(path: str) -> List[Dict[str, str]]:
@@ -38,6 +44,14 @@ def run_steps(steps: List[Dict[str, str]]) -> None:
                 page.click(step["selector"])
             elif action == "fill":
                 page.fill(step["selector"], step["text"])
+            elif action == "wait_for_selector":
+                page.wait_for_selector(step["selector"])
+            elif action == "assert_url_contains":
+                expected = step["text"]
+                if expected not in page.url:
+                    raise AssertionError(
+                        f"URL '{page.url}' does not contain '{expected}'"
+                    )
             else:
                 raise ValueError(f"Unknown action: {action}")
         browser.close()

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -14,6 +14,17 @@ def test_load_steps(tmp_path):
     assert steps == [{"action": "goto", "url": "https://example.com"}]
 
 
+def test_load_steps_allows_new_actions(tmp_path):
+    scenario = tmp_path / "scenario.json"
+    scenario.write_text(
+        '[{"action": "wait_for_selector", "selector": "#id"}, '
+        '{"action": "assert_url_contains", "text": "example"}]'
+    )
+    steps = load_steps(str(scenario))
+    assert steps[0]["action"] == "wait_for_selector"
+    assert steps[1]["action"] == "assert_url_contains"
+
+
 def test_load_steps_requires_action(tmp_path):
     scenario = tmp_path / "scenario.json"
     scenario.write_text('[{"url": "https://example.com"}]')

--- a/youtube_scenario.json
+++ b/youtube_scenario.json
@@ -1,0 +1,7 @@
+[
+  {"action": "goto", "url": "https://www.youtube.com"},
+  {"action": "wait_for_selector", "selector": "ytd-rich-grid-media a#video-title"},
+  {"action": "click", "selector": "ytd-rich-grid-media a#video-title"},
+  {"action": "wait_for_selector", "selector": "ytd-watch-flexy"},
+  {"action": "assert_url_contains", "text": "watch"}
+]


### PR DESCRIPTION
## Summary
- extend runner with `wait_for_selector` and `assert_url_contains` actions
- document new actions and add a YouTube navigation scenario
- cover new actions with unit tests

## Testing
- `pytest`
- `python runner.py youtube_scenario.json` *(fails: BrowserType.launch: Executable doesn't exist; run `playwright install`)*

------
https://chatgpt.com/codex/tasks/task_e_68aa01f2dac88320b8c631b2239bd32e